### PR TITLE
Blocked function bug

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -149,7 +149,7 @@ var Calendar = new Class({
 				for (var j = count; j >= 0; j--){
 					if (values[i][j].contains('-')){ // a range
 						var val = values[i][j].split('-');
-						for (var k = val[0]; k <= val[1]; k++){
+						for (var k = parseInt(val[0]); k <= parseInt(val[1]); k++){
 							if (!values[i].contains(k)){ values[i].push(k + ''); }
 						}
 						values[i].splice(j, 1);


### PR DESCRIPTION
If I use a date range it doesn't always run the for loop.
When I tried ['1-20 9 2011'] it would work, but if I tried ['9-20 9 2011']. It would not work. For some reason the for loop does not always compare the values as integers.
